### PR TITLE
feat: add a new `dedentRaw` which uses `raw` for the template strings array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+coverage

--- a/src/string.ts
+++ b/src/string.ts
@@ -156,7 +156,7 @@ export function dedent(
   return internal_dedent(strings, values, false);
 }
 
-dedent.escape = dedentRaw;
+dedent.raw = dedentRaw;
 
 /**
  * Removes leading and trailing whitespace from each line of a string

--- a/src/string.ts
+++ b/src/string.ts
@@ -156,7 +156,7 @@ export function dedent(
   return internal_dedent(strings, values, false);
 }
 
-dedent.escape = dedentEscape;
+dedent.escape = dedentRaw;
 
 /**
  * Removes leading and trailing whitespace from each line of a string
@@ -170,9 +170,9 @@ dedent.escape = dedentEscape;
  * // "This is a test.\nThis is another line."
  * ```
  */
-export function dedentEscape(literals: string): string;
-export function dedentEscape(strings: TemplateStringsArray, ...values: unknown[]): string;
-export function dedentEscape(
+export function dedentRaw(literals: string): string;
+export function dedentRaw(strings: TemplateStringsArray, ...values: unknown[]): string;
+export function dedentRaw(
   strings: TemplateStringsArray | string,
   ...values: unknown[]
 ): string {
@@ -183,23 +183,14 @@ export function dedentEscape(
 function internal_dedent(
   strings: TemplateStringsArray | string,
   values: unknown[],
-  escape: boolean = false,
+  raw: boolean = false,
 ): string {
-  const raw = typeof strings === "string" ? [strings] : strings.raw;
+  const _raw = typeof strings === "string" ? [strings] : raw ? strings.raw : strings;
   let result = "";
 
-  for (let i = 0; i < raw.length; i++) {
-    let next = raw[i];
+  for (let i = 0; i < _raw.length; i++) {
+    const next = _raw[i];
     result += next;
-
-    if (escape && next != null) {
-      // handle escaped newlines, backticks, and interpolation characters
-      next = next
-        .replace(/\\\n[ \t]*/g, "")
-        .replace(/\\`/g, "`")
-        .replace(/\\\$/g, "$")
-        .replace(/\\\{/g, "{");
-    }
 
     if (i < values.length) {
       result += values[i];

--- a/src/string.ts
+++ b/src/string.ts
@@ -156,6 +156,8 @@ export function dedent(
   return internal_dedent(strings, values, false);
 }
 
+dedent.escape = dedentEscape;
+
 /**
  * Removes leading and trailing whitespace from each line of a string
  * @param {TemplateStringsArray | string} literals - The string to dedent

--- a/src/string.ts
+++ b/src/string.ts
@@ -140,12 +140,12 @@ export function toSnakeCase(str: string): string {
  * @param {TemplateStringsArray | string} literals - The string to dedent
  * @returns {string} The dedented string
  * @example ```ts
-dedent`
-  This is a test.
-  This is another line.
-`
-// "This is a test.\nThis is another line."
-```
+ * dedent`
+ *   This is a test.
+ *   This is another line.
+ * `
+ * // "This is a test.\nThis is another line."
+ * ```
  */
 export function dedent(literals: string): string;
 export function dedent(strings: TemplateStringsArray, ...values: unknown[]): string;
@@ -153,12 +153,51 @@ export function dedent(
   strings: TemplateStringsArray | string,
   ...values: unknown[]
 ): string {
+  return internal_dedent(strings, values, false);
+}
+
+/**
+ * Removes leading and trailing whitespace from each line of a string
+ * @param {TemplateStringsArray | string} literals - The string to dedent
+ * @returns {string} The dedented string
+ * @example ```ts
+ * dedent`
+ *   This is a test.
+ *   This is another line.
+ * `
+ * // "This is a test.\nThis is another line."
+ * ```
+ */
+export function dedentEscape(literals: string): string;
+export function dedentEscape(strings: TemplateStringsArray, ...values: unknown[]): string;
+export function dedentEscape(
+  strings: TemplateStringsArray | string,
+  ...values: unknown[]
+): string {
+  return internal_dedent(strings, values, true);
+}
+
+/** @internal */
+function internal_dedent(
+  strings: TemplateStringsArray | string,
+  values: unknown[],
+  escape: boolean = false,
+): string {
   const raw = typeof strings === "string" ? [strings] : strings.raw;
   let result = "";
-  for (let i = 0; i < raw.length; i++) {
-    const next = raw[i];
 
+  for (let i = 0; i < raw.length; i++) {
+    let next = raw[i];
     result += next;
+
+    if (escape && next != null) {
+      // handle escaped newlines, backticks, and interpolation characters
+      next = next
+        .replace(/\\\n[ \t]*/g, "")
+        .replace(/\\`/g, "`")
+        .replace(/\\\$/g, "$")
+        .replace(/\\\{/g, "{");
+    }
 
     if (i < values.length) {
       result += values[i];

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -185,3 +185,55 @@ describe("dedent", () => {
     expect(dedent(input)).toEqual(expected);
   });
 });
+
+describe("dedentEscape", () => {
+  it("should handle escaped newlines", () => {
+    const input = `
+      hello\
+      world
+    `;
+    const expected = "helloworld";
+    expect(dedent.escape(input)).toEqual(expected);
+  });
+
+  it("should handle escaped backticks", () => {
+    const input = `
+      const code = \`hello\`;
+    `;
+    const expected = "const code = `hello`;";
+    expect(dedent.escape(input)).toEqual(expected);
+  });
+
+  it("should handle escaped interpolation", () => {
+    const input = String.raw`
+      \${notVariable}
+      \${123}
+    `;
+    const expected = String.raw`\${notVariable}
+\${123}`;
+    expect(dedent.escape(input)).toEqual(expected);
+  });
+
+  it("should handle escaped curly braces", () => {
+    const input = `
+      function test() \{
+        return true;
+      \}
+    `;
+    const expected = "function test() {\n  return true;\n}";
+    expect(dedent.escape(input)).toEqual(expected);
+  });
+
+  it("should handle mixed escaped and unescaped content", () => {
+    const name = "world";
+    const input = dedent.escape`
+      hello \${escaped}
+      ${name} \`code\`
+      \{object\}
+    `;
+    const expected = String.raw`hello \${escaped}
+world \`code\`
+{object}`;
+    expect(input).toEqual(expected);
+  });
+});

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { capitalize, dedent, toCamelCase, toKebabCase, toPascalCase, toSnakeCase } from "../src/string";
+import { capitalize, dedent, dedentRaw, toCamelCase, toKebabCase, toPascalCase, toSnakeCase } from "../src/string";
 
 describe("capitalize", () => {
   it.each([
@@ -187,53 +187,84 @@ describe("dedent", () => {
 });
 
 describe("dedentEscape", () => {
-  it("should handle escaped newlines", () => {
+  it("should handle string literals", () => {
     const input = `
-      hello\
-      world
+      const str = "hello";
+      console.log(str);
     `;
-    const expected = "helloworld";
-    expect(dedent.escape(input)).toEqual(expected);
+    const expected = "const str = \"hello\";\nconsole.log(str);";
+    expect(dedentRaw(input)).toEqual(expected);
   });
 
-  it("should handle escaped backticks", () => {
-    const input = `
-      const code = \`hello\`;
-    `;
-    const expected = "const code = `hello`;";
-    expect(dedent.escape(input)).toEqual(expected);
-  });
-
-  it("should handle escaped interpolation", () => {
-    const input = String.raw`
-      \${notVariable}
-      \${123}
-    `;
-    const expected = String.raw`\${notVariable}
-\${123}`;
-    expect(dedent.escape(input)).toEqual(expected);
-  });
-
-  it("should handle escaped curly braces", () => {
-    const input = `
-      function test() \{
-        return true;
-      \}
-    `;
-    const expected = "function test() {\n  return true;\n}";
-    expect(dedent.escape(input)).toEqual(expected);
-  });
-
-  it("should handle mixed escaped and unescaped content", () => {
+  it("should handle template literals", () => {
     const name = "world";
-    const input = dedent.escape`
-      hello \${escaped}
-      ${name} \`code\`
-      \{object\}
+    const input = dedentRaw`
+      const greeting = "hello ${name}";
+      console.log(greeting);
     `;
-    const expected = String.raw`hello \${escaped}
-world \`code\`
-{object}`;
+    const expected = "const greeting = \"hello world\";\nconsole.log(greeting);";
+    expect(input).toEqual(expected);
+  });
+
+  it("should handle raw template strings", () => {
+    const input = String.raw`
+      const regex = /\d+/;
+      const str = "hello\nworld";
+    `;
+    const expected = "const regex = /\\d+/;\nconst str = \"hello\\nworld\";";
+    expect(dedentRaw(input)).toEqual(expected);
+  });
+
+  it("should handle mixed indentation", () => {
+    const input = `
+      // 2 spaces
+        // 4 spaces
+      // back to 2
+    `;
+    const expected = "// 2 spaces\n  // 4 spaces\n// back to 2";
+    expect(dedentRaw(input)).toEqual(expected);
+  });
+
+  it("should handle empty strings", () => {
+    expect(dedentRaw("")).toEqual("");
+  });
+
+  it("should handle single line strings", () => {
+    expect(dedentRaw("  hello  ")).toEqual("hello  ");
+  });
+
+  it("should preserve empty lines in the middle", () => {
+    const input = `
+      line1
+
+      line2
+    `;
+    const expected = "line1\n\nline2";
+    expect(dedentRaw(input)).toEqual(expected);
+  });
+
+  it("should handle strings with only whitespace", () => {
+    const input = "  \n    \n  ";
+    expect(dedentRaw(input)).toEqual("\n\n");
+  });
+
+  it("should handle strings with unicode whitespace", () => {
+    const input = `
+      hello\u200B
+        world\u200B
+    `;
+    const expected = "hello\u200B\n  world\u200B";
+    expect(dedentRaw(input)).toEqual(expected);
+  });
+
+  it("should handle template literals with expressions", () => {
+    const a = 1;
+    const b = 2;
+    const input = dedentRaw`
+      ${a} + ${b} = ${a + b}
+        nested ${a + b} math
+    `;
+    const expected = "1 + 2 = 3\n  nested 3 math";
     expect(input).toEqual(expected);
   });
 });

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -173,4 +173,15 @@ describe("dedent", () => {
     const expected = "hello\n  world\n    !";
     expect(input).toEqual(expected);
   });
+
+  it("should handle text with unicode spaces", () => {
+    const input = `
+      hello\u200B
+        world\u200B
+          !
+    `;
+
+    const expected = "hello\u200B\n  world\u200B\n    !";
+    expect(dedent(input)).toEqual(expected);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*", "test/number.test.ts", "test/string.test.ts", "test/types.test.ts", "test/guards.test.ts"],
+  "include": [
+    "src/**/*"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      include: ["src/**/*.{ts,tsx}"],
+    },
+  },
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new raw-string-aware dedent function available as `dedentRaw` and as a property of the existing `dedent` function.

- **Bug Fixes**
  - Improved handling of Unicode zero-width space characters during string dedenting.

- **Tests**
  - Added extensive tests covering the new raw dedent function and Unicode whitespace preservation.

- **Chores**
  - Updated `.gitignore` to exclude coverage files.
  - Simplified TypeScript configuration to include only source files.
  - Added Vitest configuration for test coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->