### PR TITLE
feat!: drop support for cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,49 +23,14 @@
   ],
   "sideEffects": false,
   "exports": {
-    ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
-    },
-    "./guards": {
-      "import": {
-        "types": "./dist/guards.d.ts",
-        "default": "./dist/guards.js"
-      },
-      "require": {
-        "types": "./dist/guards.d.cts",
-        "default": "./dist/guards.cjs"
-      }
-    },
-    "./number": {
-      "import": {
-        "types": "./dist/number.d.ts",
-        "default": "./dist/number.js"
-      },
-      "require": {
-        "types": "./dist/number.d.cts",
-        "default": "./dist/number.cjs"
-      }
-    },
-    "./types": {
-      "import": {
-        "types": "./dist/types.d.ts",
-        "default": "./dist/types.js"
-      },
-      "require": {
-        "types": "./dist/types.d.cts",
-        "default": "./dist/types.cjs"
-      }
-    },
+    ".": "./dist/index.js",
+    "./string": "./dist/string.js",
+    "./guards": "./dist/guards.js",
+    "./number": "./dist/number.js",
+    "./types": "./dist/types.js",
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -91,6 +56,7 @@
     "publint": "^0.3.12",
     "tsdown": "^0.9.9",
     "typescript": "^5.8.3",
-    "vitest": "^3.1.2"
+    "vitest": "^3.1.2",
+    "vitest-package-exports": "^0.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       vitest:
         specifier: ^3.1.2
         version: 3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.0)
+      vitest-package-exports:
+        specifier: ^0.1.1
+        version: 0.1.1
 
 packages:
 
@@ -2415,6 +2418,9 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-package-exports@0.1.1:
+    resolution: {integrity: sha512-rXgU5noxaaMA5VJXgVPhXRzPiQ1WFmWwgo8dQFPg9j/yFM028scO0IAylFHVI8XMRevhozEt1usa6RQYQY26lg==}
 
   vitest@3.1.2:
     resolution: {integrity: sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==}
@@ -4999,6 +5005,11 @@ snapshots:
       jiti: 2.4.2
       lightningcss: 1.29.3
       yaml: 2.7.0
+
+  vitest-package-exports@0.1.1:
+    dependencies:
+      find-up-simple: 1.0.1
+      pathe: 2.0.3
 
   vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.29.3)(yaml@2.7.0):
     dependencies:

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,0 +1,50 @@
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+import { getPackageExportsManifest } from "vitest-package-exports";
+
+it("exports-snapshot", async () => {
+  const manifest = await getPackageExportsManifest({
+    importMode: "src",
+    cwd: fileURLToPath(import.meta.url),
+  });
+
+  expect(manifest.exports).toMatchInlineSnapshot(`
+      {
+        ".": {
+          "capitalize": "function",
+          "clamp": "function",
+          "dedent": "function",
+          "dedentRaw": "function",
+          "isNotNull": "function",
+          "isNotNullish": "function",
+          "isNotUndefined": "function",
+          "isTruthy": "function",
+          "sanitizeIdentifier": "function",
+          "toCamelCase": "function",
+          "toKebabCase": "function",
+          "toPascalCase": "function",
+          "toSnakeCase": "function",
+        },
+        "./guards": {
+          "isNotNull": "function",
+          "isNotNullish": "function",
+          "isNotUndefined": "function",
+          "isTruthy": "function",
+        },
+        "./number": {
+          "clamp": "function",
+        },
+        "./string": {
+          "capitalize": "function",
+          "dedent": "function",
+          "dedentRaw": "function",
+          "sanitizeIdentifier": "function",
+          "toCamelCase": "function",
+          "toKebabCase": "function",
+          "toPascalCase": "function",
+          "toSnakeCase": "function",
+        },
+        "./types": {},
+      }
+  `);
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     "./src/guards.ts",
     "./src/number.ts",
   ],
-  format: ["esm", "cjs"],
+  format: "esm",
   clean: true,
   dts: true,
   treeshake: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    server: {
+      deps: {
+        inline: ["vitest-package-exports"],
+      },
+    },
     coverage: {
       include: ["src/**/*.{ts,tsx}"],
     },


### PR DESCRIPTION
This PR drops support for CJS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new export for string utilities.
  - Introduced tests to verify the package's public exports.

- **Chores**
  - Simplified and updated the package exports for improved compatibility.
  - Changed the build output to only generate ECMAScript modules.
  - Updated test configuration to support export verification.
  - Added a new development dependency for testing package exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->